### PR TITLE
fix: initialize svc annotations

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -265,8 +265,9 @@ func newEtcdServiceManifest(svcName, clusterName string, ports []v1.ServicePort,
 	labels := LabelsForCluster(clusterName)
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   svcName,
-			Labels: labels,
+			Name:        svcName,
+			Labels:      labels,
+			Annotations: map[string]string{},
 		},
 		Spec: v1.ServiceSpec{
 			Ports:                    ports,


### PR DESCRIPTION
initialize Annotations in the new ETCD service manifest