### PR TITLE
fix: token creation in all flows

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -30,7 +30,6 @@ import (
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
 
-	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -404,7 +403,12 @@ func (c *Cluster) isPodPVEnabled() bool {
 }
 
 func (c *Cluster) createPod(ctx context.Context, members etcdutil.MemberSet, m *etcdutil.Member, state string) error {
-	pod, err := k8sutil.NewEtcdPod(ctx, c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
+	token, err := k8sutil.CreateToken(c.cluster.Spec)
+	if err != nil {
+		return err
+	}
+	
+	pod, err := k8sutil.NewEtcdPod(ctx, c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, token, c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewEtcdPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
 		_, err := c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(ctx, pvc, metav1.CreateOptions{})

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -313,7 +313,7 @@ func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {
 	o.SetOwnerReferences(append(o.GetOwnerReferences(), r))
 }
 
-func createToken(clusterSpec api.ClusterSpec) (string, error) {
+func CreateToken(clusterSpec api.ClusterSpec) (string, error) {
 	if clusterSpec.ClusteringMode == "discovery" {
 		if clusterSpec.ClusterToken == "" {
 			return "", ErrDiscoveryTokenNotProvided
@@ -328,7 +328,7 @@ func createToken(clusterSpec api.ClusterSpec) (string, error) {
 // NewSeedMemberPod returns a Pod manifest for a seed member.
 // It's special that it has new token, and might need recovery init containers
 func NewSeedMemberPod(ctx context.Context, kubecli kubernetes.Interface, clusterName, clusterNamespace string, ms etcdutil.MemberSet, m *etcdutil.Member, cs api.ClusterSpec, owner metav1.OwnerReference, backupURL *url.URL) (*v1.Pod, error) {
-	token, err := createToken(cs)
+	token, err := CreateToken(cs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -169,7 +169,7 @@ func TestCreateTokenLocalCluster(t *testing.T) {
 		ClusterToken:   "testtoken",
 	}
 
-	token, _ := createToken(*clusterSpec)
+	token, _ := CreateToken(*clusterSpec)
 
 	if token == "testtoken" {
 		t.Errorf("token should be a randon uuid, instead got %s", token)
@@ -182,7 +182,7 @@ func TestCreateTokenDiscoveryClusterNoTokenSent(t *testing.T) {
 		ClusteringMode: "discovery",
 	}
 
-	_, err := createToken(*clusterSpec)
+	_, err := CreateToken(*clusterSpec)
 
 	if err == nil {
 		t.Errorf("Expected an error to be thrown when discovery mode on and no token is set")
@@ -196,7 +196,7 @@ func TestCreateTokenDiscoveryClusterTokenEmpty(t *testing.T) {
 		ClusterToken: "",
 	}
 
-	_, err := createToken(*clusterSpec)
+	_, err := CreateToken(*clusterSpec)
 
 	if err == nil {
 		t.Errorf("Expected an error to be thrown when discovery mode on and no token is set")
@@ -210,9 +210,22 @@ func TestCreateTokenDistributedCluster(t *testing.T) {
 		ClusterToken:   "testtoken",
 	}
 
-	token, _ := createToken(*clusterSpec)
+	token, _ := CreateToken(*clusterSpec)
 
 	if token != "testtoken" {
 		t.Errorf("expected token=%s, got=%s", clusterSpec.ClusterToken, token)
+	}
+}
+
+func TestCreateTokenNoMode(t *testing.T) {
+	clusterSpec := &api.ClusterSpec{
+		Size:           1,
+		ClusterToken:   "testtoken",
+	}
+
+	token, _ := CreateToken(*clusterSpec)
+
+	if token == "testtoken" {
+		t.Errorf("expected random uiid token, got=%s", clusterSpec.ClusterToken)
 	}
 }


### PR DESCRIPTION
## Problem statement

When testing this

token: `f62a4d061f03ebe8b0ba8db8d010c988`

command generated:

`{"level":"info","ts":"2023-04-04T18:51:26.251Z","caller":"etcdmain/etcd.go:73","msg":"Running: ","args":["/usr/local/bin/etcd","--data-dir=/var/etcd/data","--name=etcd-cluster-c9nqcdk5vp","--initial-advertise-peer-urls=http://etcd-cluster-c9nqcdk5vp.etcd-cluster.etcd.svc:2380","--listen-peer-urls=http://0.0.0.0:2380","--listen-client-urls=http://0.0.0.0:2379","--advertise-client-urls=http://etcd-cluster-c9nqcdk5vp.etcd-cluster.etcd.svc:2379","--discovery=https://discovery.etcd.io/68898fb7-f5b3-4a58-ac13-52c5fe462544"]}`

Which lead to a failed cluster

```
{"level":"warn","ts":"2023-04-04T18:51:26.391Z","caller":"etcdmain/etcd.go:146","msg":"failed to start etcd","error":"failed to join discovery cluster (discovery: bad discovery endpoint)"}
{"level":"warn","ts":"2023-04-04T18:51:26.391Z","caller":"etcdmain/etcd.go:181","msg":"failed to bootstrap; discovery token was already used","discovery-token":"https://discovery.etcd.io/68898fb7-f5b3-4a58-ac13-52c5fe462544","error":"failed to join discovery cluster (discovery: bad discovery endpoint)"}
{"level":"warn","ts":"2023-04-04T18:51:26.391Z","caller":"etcdmain/etcd.go:186","msg":"do not reuse discovery token; generate a new one to bootstrap a cluster"}
```