### PR TITLE
Fix discovery service creation

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -413,7 +413,10 @@ func (c *Cluster) createPod(ctx context.Context, members etcdutil.MemberSet, m *
 		return err
 	}
 	
-	pod, _ := k8sutil.NewEtcdPod(ctx, c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, token, c.cluster.Spec, c.cluster.AsOwner())
+	pod, err := k8sutil.NewEtcdPod(ctx, c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, token, c.cluster.Spec, c.cluster.AsOwner())
+	if err != nil {
+		return err
+	}
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewEtcdPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
 		_, err := c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(ctx, pvc, metav1.CreateOptions{})

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -155,6 +155,11 @@ func (c *Cluster) setup(ctx context.Context) error {
 	}
 
 	if shouldCreateCluster {
+		if c.cluster.Spec.ClusteringMode == "discovery" {
+			if err := c.setupServices(ctx); err != nil {
+				c.logger.Errorf("fail to setup etcd services: %v", err)
+			}
+		}
 		return c.create(ctx)
 	}
 	return nil
@@ -408,7 +413,7 @@ func (c *Cluster) createPod(ctx context.Context, members etcdutil.MemberSet, m *
 		return err
 	}
 	
-	pod, err := k8sutil.NewEtcdPod(ctx, c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, token, c.cluster.Spec, c.cluster.AsOwner())
+	pod, _ := k8sutil.NewEtcdPod(ctx, c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, token, c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewEtcdPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
 		_, err := c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(ctx, pvc, metav1.CreateOptions{})

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -378,21 +378,21 @@ func (c *Cluster) Update(cl *api.EtcdCluster) {
 func (c *Cluster) setupServices(ctx context.Context) error {
 	if c.cluster.Spec.Services != nil {
 		for _, service := range c.cluster.Spec.Services {
-			err := k8sutil.CreateClientService(ctx, c.config.KubeCli, service.Name, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient(), service)
+			err := k8sutil.CreateClientService(ctx, c.config.KubeCli, service.Name, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient(), service, c.cluster.Spec.ClusteringMode, k8sutil.CreateSvc)
 			if err != nil {
 				return err
 			}
 			c.status.ServiceName = append(c.status.ServiceName, service.Name)
 		}
 	} else {
-		err := k8sutil.CreateClientService(ctx, c.config.KubeCli, k8sutil.ClientServiceName(c.cluster.Name), c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient(), nil)
+		err := k8sutil.CreateClientService(ctx, c.config.KubeCli, k8sutil.ClientServiceName(c.cluster.Name), c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient(), nil,  c.cluster.Spec.ClusteringMode, k8sutil.CreateSvc)
 		if err != nil {
 			return err
 		}
 		c.status.ServiceName = append(c.status.ServiceName, k8sutil.ClientServiceName(c.cluster.Name))
 	}
 
-	return k8sutil.CreatePeerService(ctx, c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient())
+	return k8sutil.CreatePeerService(ctx, c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient(),  c.cluster.Spec.ClusteringMode, k8sutil.CreateSvc)
 }
 
 func (c *Cluster) isPodPVEnabled() bool {

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -129,7 +129,7 @@ func (c *Cluster) reconcileServices(ctx context.Context, services map[string]*v1
 
 	if len(newServices) > 0 {
 		for _, service := range newServices {
-			err := k8sutil.CreateClientService(ctx, c.config.KubeCli, service.Name, c.cluster.GetName(), c.cluster.GetNamespace(), c.cluster.AsOwner(), c.isSecureClient(), service)
+			err := k8sutil.CreateClientService(ctx, c.config.KubeCli, service.Name, c.cluster.GetName(), c.cluster.GetNamespace(), c.cluster.AsOwner(), c.isSecureClient(), service, c.cluster.Spec.ClusteringMode, k8sutil.CreateSvc)
 			if err != nil {
 				return err
 			}

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -45,7 +45,7 @@ func (c *Cluster) reconcile(ctx context.Context, pods []*v1.Pod, services map[st
 
 	sp := c.cluster.Spec
 	if c.cluster.Spec.Services != nil {
-		c.reconcileServices(ctx, services)
+		c.reconcileServices(ctx, services, k8sutil.CreateSvc)
 		c.status.SetClusterServiceName(services)
 	}
 
@@ -120,7 +120,7 @@ func (c *Cluster) diffServices(services map[string]*v1.Service) ([]*api.ServiceP
 	return newServices, unknownServices, nil
 }
 
-func (c *Cluster) reconcileServices(ctx context.Context, services map[string]*v1.Service) error {
+func (c *Cluster) reconcileServices(ctx context.Context, services map[string]*v1.Service, createSvc k8sutil.CreateService) error {
 
 	newServices, unknownServices, err := c.diffServices(services)
 	if err != nil {
@@ -129,7 +129,7 @@ func (c *Cluster) reconcileServices(ctx context.Context, services map[string]*v1
 
 	if len(newServices) > 0 {
 		for _, service := range newServices {
-			err := k8sutil.CreateClientService(ctx, c.config.KubeCli, service.Name, c.cluster.GetName(), c.cluster.GetNamespace(), c.cluster.AsOwner(), c.isSecureClient(), service, c.cluster.Spec.ClusteringMode, k8sutil.CreateSvc)
+			err := k8sutil.CreateClientService(ctx, c.config.KubeCli, service.Name, c.cluster.GetName(), c.cluster.GetNamespace(), c.cluster.AsOwner(), c.isSecureClient(), service, c.cluster.Spec.ClusteringMode, createSvc)
 			if err != nil {
 				return err
 			}

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -105,7 +105,7 @@ func getServiceStatus(ctx context.Context, kubecli kubernetes.Interface, svcName
 		if err != nil {
 			status <- err.Error()
 		}
-		if len(service.Status.LoadBalancer.Ingress) == 0 {
+		if service.Spec.Type == v1.ServiceTypeLoadBalancer && len(service.Status.LoadBalancer.Ingress) == 0 {
 			time.Sleep(30 * time.Second)
 		} else {
 			status <- "created"

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -109,7 +109,7 @@ func getServiceStatus(ctx context.Context, kubecli kubernetes.Interface, svcName
 			time.Sleep(30 * time.Second)
 		} else {
 			status <- "created"
-			break
+			return
 		}
 	}
 	status <- "timeout creating service"

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -81,7 +81,7 @@ const (
 
 var ErrDiscoveryTokenNotProvided = errors.New("cluster token not provided, you must provide a token when clustering mode is discovery")
 
-var CreateSvc createService = func(ctx context.Context, kubecli kubernetes.Interface, svcName string, clusterName string, ns string, ports []v1.ServicePort, owner metav1.OwnerReference, publishNotReadyAddresses bool, service *api.ServicePolicy, annotations map[string]string) error {
+var CreateSvc CreateService = func(ctx context.Context, kubecli kubernetes.Interface, svcName string, clusterName string, ns string, ports []v1.ServicePort, owner metav1.OwnerReference, publishNotReadyAddresses bool, service *api.ServicePolicy, annotations map[string]string) error {
 	svc := newEtcdServiceManifest(svcName, clusterName, ports, publishNotReadyAddresses, annotations)
 
     applyServicePolicy(svc, service)
@@ -191,7 +191,7 @@ func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {
 	return p
 }
 
-func CreateClientService(ctx context.Context, kubecli kubernetes.Interface, serviceName, clusterName, ns string, owner metav1.OwnerReference, tls bool, service *api.ServicePolicy, clusteringMode string, createSvc createService) error {
+func CreateClientService(ctx context.Context, kubecli kubernetes.Interface, serviceName, clusterName, ns string, owner metav1.OwnerReference, tls bool, service *api.ServicePolicy, clusteringMode string, createSvc CreateService) error {
 
 	if len(serviceName) == 0 {
 		return fmt.Errorf("fail to create service: name isn't defined")
@@ -240,7 +240,7 @@ func CreateClientService(ctx context.Context, kubecli kubernetes.Interface, serv
 	return err
 }
 
-func CreatePeerService(ctx context.Context, kubecli kubernetes.Interface, clusterName, ns string, owner metav1.OwnerReference, tls bool, clusteringMode string, createSvc createService) error {
+func CreatePeerService(ctx context.Context, kubecli kubernetes.Interface, clusterName, ns string, owner metav1.OwnerReference, tls bool, clusteringMode string, createSvc CreateService) error {
 
 	var EtcdClientPortName string
 	if tls {
@@ -282,7 +282,7 @@ func CreatePeerService(ctx context.Context, kubecli kubernetes.Interface, cluste
 }
 
 type (
-	createService func(ctx context.Context, kubecli kubernetes.Interface, svcName string, clusterName string, ns string, ports []v1.ServicePort, owner metav1.OwnerReference, publishNotReadyAddresses bool, service *api.ServicePolicy, annotations map[string]string) error
+	CreateService func(ctx context.Context, kubecli kubernetes.Interface, svcName string, clusterName string, ns string, ports []v1.ServicePort, owner metav1.OwnerReference, publishNotReadyAddresses bool, service *api.ServicePolicy, annotations map[string]string) error
 )
 
 // CreateAndWaitPod creates a pod and waits until it is running

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -400,6 +400,7 @@ func setupClientServiceURL(endpoint string) string {
 
 func setupEtcdCommand(dataDir string, m *etcdutil.Member, initialCluster string, clusterState string, clusterToken string, clusteringMode string, service v1.Service) (string, error) {
 	if clusteringMode == "discovery" {
+		fmt.Printf("Services url list: %v", service.Status.LoadBalancer.Ingress)
 		serviceUrl := service.Status.LoadBalancer.Ingress[0].Hostname
 		if serviceUrl == "" {
 			return "", fmt.Errorf("failed to get service url: %v", service)
@@ -425,7 +426,9 @@ func newEtcdPod(ctx context.Context, kubecli kubernetes.Interface, m *etcdutil.M
 	var service v1.Service
 	if cs.ClusteringMode == "discovery" {
 		services, err := kubecli.CoreV1().Services(clusterNamespace).List(ctx, metav1.ListOptions{})
+		fmt.Printf("Services list: %v", services)
 		if err != nil {
+			fmt.Printf("%s",err.Error())
 			return nil, err
 		}
 		for _, svc := range services.Items {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -204,7 +204,6 @@ func CreateClientService(ctx context.Context, kubecli kubernetes.Interface, serv
 		if clusteringMode == "discovery" {
 			service = &api.ServicePolicy{
 				Type:      v1.ServiceTypeLoadBalancer,
-				ClusterIP: v1.ClusterIPNone,
 			}
 			annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"] = "instance"
 			annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "external"
@@ -245,7 +244,6 @@ func CreatePeerService(ctx context.Context, kubecli kubernetes.Interface, cluste
 	if clusteringMode == "discovery"{
 		service = &api.ServicePolicy{
 			Type:      v1.ServiceTypeLoadBalancer,
-			ClusterIP: v1.ClusterIPNone,
 		}
 		annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"] = "instance"
 		annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "external"

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -564,9 +564,12 @@ func podSecurityContext(podPolicy *api.PodPolicy) *v1.PodSecurityContext {
 
 func NewEtcdPod(ctx context.Context, kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster []string, clusterName, clusterNamespace, state, token string, cs api.ClusterSpec, owner metav1.OwnerReference) (*v1.Pod, error) {
 	pod, err := newEtcdPod(ctx, kubecli, m, initialCluster, clusterName, clusterNamespace, state, token, cs)
+	if err != nil {
+		return nil, err
+	}
 	applyPodPolicy(clusterName, pod, cs.Pod)
 	addOwnerRefToObject(pod.GetObjectMeta(), owner)
-	return pod, err
+	return pod, nil
 }
 
 func MustNewKubeClient() kubernetes.Interface {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -400,7 +400,7 @@ func setupClientServiceURL(endpoint string) string {
 
 func setupEtcdCommand(dataDir string, m *etcdutil.Member, initialCluster string, clusterState string, clusterToken string, clusteringMode string, service v1.Service) (string, error) {
 	if clusteringMode == "discovery" {
-		serviceUrl := service.Spec.ExternalName
+		serviceUrl := service.Status.LoadBalancer.Ingress[0].Hostname
 		command := fmt.Sprintf("/usr/local/bin/etcd --data-dir=%s --name=%s --initial-advertise-peer-urls=%s "+
 			"--listen-peer-urls=%s --listen-client-urls=%s --advertise-client-urls=%s "+
 			"--discovery=%s/%s",

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -401,6 +401,9 @@ func setupClientServiceURL(endpoint string) string {
 func setupEtcdCommand(dataDir string, m *etcdutil.Member, initialCluster string, clusterState string, clusterToken string, clusteringMode string, service v1.Service) (string, error) {
 	if clusteringMode == "discovery" {
 		serviceUrl := service.Status.LoadBalancer.Ingress[0].Hostname
+		if serviceUrl == "" {
+			return "", fmt.Errorf("failed to get service url: %v", service)
+		}
 		command := fmt.Sprintf("/usr/local/bin/etcd --data-dir=%s --name=%s --initial-advertise-peer-urls=%s "+
 			"--listen-peer-urls=%s --listen-client-urls=%s --advertise-client-urls=%s "+
 			"--discovery=%s/%s",
@@ -426,7 +429,7 @@ func newEtcdPod(ctx context.Context, kubecli kubernetes.Interface, m *etcdutil.M
 			return nil, err
 		}
 		for _, svc := range services.Items {
-			if svc.Name == clusterName {
+			if svc.ObjectMeta.Name == clusterName {
 				service = svc
 			}
 		}

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -100,12 +100,11 @@ var CreateSvc createService = func(ctx context.Context, kubecli kubernetes.Inter
 }
 
 func getServiceStatus(ctx context.Context, kubecli kubernetes.Interface, svcName string, ns string, status chan string) {
-	service, err := kubecli.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
-	if err != nil {
-		status <- err.Error()
-	}
-
 	for i := 0; i < 20; i++ {
+		service, err := kubecli.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
+		if err != nil {
+			status <- err.Error()
+		}
 		if len(service.Status.LoadBalancer.Ingress) == 0 {
 			time.Sleep(30 * time.Second)
 		} else {

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -69,8 +69,9 @@ func TestEtcdCommandNewLocalCluster(t *testing.T) {
 	memberSet := etcdutil.NewMemberSet(etcdMember).PeerURLPairs()
 	clusterState := "new"
 	token := "token"
+	service := v1.Service{}
 
-	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember, strings.Join(memberSet, ","), clusterState, token, "")
+	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember, strings.Join(memberSet, ","), clusterState, token, "", service)
 
 	expectedCommand := "/usr/local/bin/etcd --data-dir=/var/etcd/data --name=etcd-test --initial-advertise-peer-urls=http://etcd-test.etcd.etcd.svc.local:2380 " +
 		"--listen-peer-urls=http://0.0.0.0:2380 --listen-client-urls=http://0.0.0.0:2379 --advertise-client-urls=http://etcd-test.etcd.etcd.svc.local:2379 " +
@@ -103,8 +104,9 @@ func TestEtcdCommandExistingLocalCluster(t *testing.T) {
 	memberSetURLs := memberSet.PeerURLPairs()
 	token := "token"
 	clusterState := "existing"
+	service := v1.Service{}
 
-	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember2, strings.Join(memberSetURLs, ","), clusterState, token, "")
+	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember2, strings.Join(memberSetURLs, ","), clusterState, token, "", service)
 
 	commandBeforeClusterSet := "/usr/local/bin/etcd --data-dir=/var/etcd/data --name=etcd-test-2 --initial-advertise-peer-urls=http://etcd-test-2.etcd-test.etcd.svc.local:2380 " +
 		"--listen-peer-urls=http://0.0.0.0:2380 --listen-client-urls=http://0.0.0.0:2379 --advertise-client-urls=http://etcd-test-2.etcd-test.etcd.svc.local:2379 "
@@ -132,8 +134,9 @@ func TestEtcdCommandInvalidClusterMode(t *testing.T) {
 	clusterState := "new"
 	token := "token"
 	clusteringMode := "invalid"
+	service := v1.Service{}
 
-	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember, strings.Join(memberSet, ","), clusterState, token, clusteringMode)
+	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember, strings.Join(memberSet, ","), clusterState, token, clusteringMode, service)
 
 	expectedCommand := "/usr/local/bin/etcd --data-dir=/var/etcd/data --name=etcd-test --initial-advertise-peer-urls=http://etcd-test.etcd.etcd.svc.local:2380 " +
 		"--listen-peer-urls=http://0.0.0.0:2380 --listen-client-urls=http://0.0.0.0:2379 --advertise-client-urls=http://etcd-test.etcd.etcd.svc.local:2379 " +
@@ -157,11 +160,16 @@ func TestEtcdCommandDiscoveryCluster(t *testing.T) {
 	clusterState := "new"
 	clusterToken := "token"
 	clusteringMode := "discovery"
+	service := v1.Service{
+		Spec : v1.ServiceSpec{
+			ExternalName: "etcd-peer",
+		},
+	}
 
-	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember, strings.Join(memberSet, ","), clusterState, clusterToken, clusteringMode)
+	initialEtcdCommand, _ := setupEtcdCommand(dataDir, etcdMember, strings.Join(memberSet, ","), clusterState, clusterToken, clusteringMode, service)
 
-	expectedCommand := "/usr/local/bin/etcd --data-dir=/var/etcd/data --name=etcd-test --initial-advertise-peer-urls=http://etcd-test.etcd.etcd.svc.local:2380 " +
-		"--listen-peer-urls=http://0.0.0.0:2380 --listen-client-urls=http://0.0.0.0:2379 --advertise-client-urls=http://etcd-test.etcd.etcd.svc.local:2379 " +
+	expectedCommand := "/usr/local/bin/etcd --data-dir=/var/etcd/data --name=etcd-test --initial-advertise-peer-urls=http://etcd-peer:2380 " +
+		"--listen-peer-urls=http://0.0.0.0:2380 --listen-client-urls=http://0.0.0.0:2379 --advertise-client-urls=http://etcd-peer:2379 " +
 		"--discovery=https://discovery.etcd.io/token"
 
 	if initialEtcdCommand != expectedCommand {

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -473,7 +473,6 @@ func TestCreatePeerServiceDiscoveryCluster(t *testing.T) {
 	}}
 	expectedService := &api.ServicePolicy{
 		Type:      v1.ServiceTypeLoadBalancer,
-		ClusterIP: v1.ClusterIPNone,
 	}
 	expectedAnnotations := map[string]string{
 		"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
@@ -852,7 +851,6 @@ func TestCreateClientServiceDiscoveryClusterNilService(t *testing.T) {
 	}}
 	expectedService := &api.ServicePolicy{
 		Type:      v1.ServiceTypeLoadBalancer,
-		ClusterIP: v1.ClusterIPNone,
 	}
 	expectedAnnotations := map[string]string{
 		"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -160,9 +160,14 @@ func TestEtcdCommandDiscoveryCluster(t *testing.T) {
 	clusterState := "new"
 	clusterToken := "token"
 	clusteringMode := "discovery"
+	hostname := v1.LoadBalancerIngress{
+		Hostname: "etcd-peer",
+	}
 	service := v1.Service{
-		Spec : v1.ServiceSpec{
-			ExternalName: "etcd-peer",
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{hostname},
+			},
 		},
 	}
 


### PR DESCRIPTION
This corrects the creation of services in the discovery mode. If that mode is set we create load balancers that can be reached from other clusters so that the etcd members can communicate.