### PR TITLE
fix: probes command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See the [Resources and Labels](./doc/user/resource_labels.md) doc for an overvie
 ## Requirements
 
 - Kubernetes 1.8+
-- etcd 3.2.13+
+- etcd 3.3+
 
 ## Demo
 
@@ -126,7 +126,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "v3.2.13"
+  version: "v3.4.19"
 ```
 ```
 $ kubectl apply -f example/example-etcd-cluster.yaml

--- a/example/example-etcd-cluster.yaml
+++ b/example/example-etcd-cluster.yaml
@@ -8,4 +8,4 @@ metadata:
   #   etcd.database.coreos.com/scope: clusterwide
 spec:
   size: 3
-  version: "v3.2.13"
+  version: "v3.4.19"

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	defaultRepository  = "quay.io/coreos/etcd"
-	DefaultEtcdVersion = "v3.2.13"
+	DefaultEtcdVersion = "v3.4.19"
 )
 
 var (
@@ -83,10 +83,10 @@ type ClusterSpec struct {
 	// The etcd-operator will eventually make the etcd cluster version
 	// equal to the expected version.
 	//
-	// The version must follow the [semver]( http://semver.org) format, for example "3.2.13".
+	// The version must follow the [semver]( http://semver.org) format, for example "v3.4.19".
 	// Only etcd released versions are supported: https://github.com/coreos/etcd/releases
 	//
-	// If version is not set, default is "v3.2.13".
+	// If version is not set, default is "v3.4.19".
 	Version string `json:"version,omitempty"`
 
 	// Paused is to pause the control of the operator for the etcd cluster.

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -423,12 +423,61 @@ func setupClientServiceURL(endpoint string) string {
 	return fmt.Sprintf("http://%s:2379", endpoint)
 }
 
+func setupInitContainerCommand(cs api.ClusterSpec, m *etcdutil.Member, service v1.Service) (string, error) {
+	DNSTimeout := defaultDNSTimeout
+	if cs.Pod != nil {
+		DNSTimeout = cs.Pod.DNSTimeoutInSecond
+	}
+	
+	if cs.ClusteringMode == "discovery" {
+		serviceUrl, err := getServiceHostname(service)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf(`
+		TIMEOUT_READY=%d
+		while ( ! nslookup %s )
+		do
+			# If TIMEOUT_READY is 0 we should never time out and exit
+			TIMEOUT_READY=$(( TIMEOUT_READY-1 ))
+			if [ $TIMEOUT_READY -eq 0 ];
+			then
+				echo "Timed out waiting for DNS entry"
+				exit 1
+			fi
+			sleep 1
+		done`, DNSTimeout, serviceUrl), nil
+	} else {
+		return fmt.Sprintf(`
+		TIMEOUT_READY=%d
+		while ( ! nslookup %s )
+		do
+			# If TIMEOUT_READY is 0 we should never time out and exit
+			TIMEOUT_READY=$(( TIMEOUT_READY-1 ))
+			if [ $TIMEOUT_READY -eq 0 ];
+			then
+				echo "Timed out waiting for DNS entry"
+				exit 1
+			fi
+			sleep 1
+		done`, DNSTimeout, m.Addr()), nil
+	}
+}
+
+func getServiceHostname(service v1.Service) (string, error) {
+	fmt.Printf("Services url list: %v", service.Status.LoadBalancer.Ingress)
+	svcUrl := service.Status.LoadBalancer.Ingress[0].Hostname
+	if svcUrl == "" {
+		return "", fmt.Errorf("failed to get service url: %v", service)
+	} else {
+		return svcUrl, nil
+	}
+}
 func setupEtcdCommand(dataDir string, m *etcdutil.Member, initialCluster string, clusterState string, clusterToken string, clusteringMode string, service v1.Service) (string, error) {
 	if clusteringMode == "discovery" {
-		fmt.Printf("Services url list: %v", service.Status.LoadBalancer.Ingress)
-		serviceUrl := service.Status.LoadBalancer.Ingress[0].Hostname
-		if serviceUrl == "" {
-			return "", fmt.Errorf("failed to get service url: %v", service)
+		serviceUrl, err := getServiceHostname(service)
+		if err != nil {
+			return "", err
 		}
 		command := fmt.Sprintf("/usr/local/bin/etcd --data-dir=%s --name=%s --initial-advertise-peer-urls=%s "+
 			"--listen-peer-urls=%s --listen-client-urls=%s --advertise-client-urls=%s "+
@@ -543,9 +592,9 @@ func newEtcdPod(ctx context.Context, kubecli kubernetes.Interface, m *etcdutil.M
 		}})
 	}
 
-	DNSTimeout := defaultDNSTimeout
-	if cs.Pod != nil {
-		DNSTimeout = cs.Pod.DNSTimeoutInSecond
+	initContainerCommand, err := setupInitContainerCommand(cs, m, service)
+	if err != nil {
+		return nil, err
 	}
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -563,19 +612,7 @@ func newEtcdPod(ctx context.Context, kubecli kubernetes.Interface, m *etcdutil.M
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.
 				// In some cases the DNS is not created correctly so we need to time out after a given period.
-				Command: []string{"/bin/sh", "-c", fmt.Sprintf(`
-					TIMEOUT_READY=%d
-					while ( ! nslookup %s )
-					do
-						# If TIMEOUT_READY is 0 we should never time out and exit
-						TIMEOUT_READY=$(( TIMEOUT_READY-1 ))
-                        if [ $TIMEOUT_READY -eq 0 ];
-				        then
-				            echo "Timed out waiting for DNS entry"
-				            exit 1
-				        fi
-						sleep 1
-					done`, DNSTimeout, m.Addr())},
+				Command: []string{"/bin/sh", "-c", initContainerCommand},
 			}},
 			Containers:    []v1.Container{container},
 			RestartPolicy: v1.RestartPolicyNever,

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -70,18 +70,18 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 
 func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	// etcd pod is healthy only if it can participate in consensus
-	cmd := "etcdctl endpoint status"
+	cmd := "endpoint status"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)
 		if isTLSSecret {
 			tlsFlags = fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, "tls.crt", "tls.key", "ca.crt")
 		}
-		cmd = fmt.Sprintf("etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
+		cmd = fmt.Sprintf("--endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
 	}
 	return &v1.Probe{
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
-				Command: []string{"/usr/local/bin/", cmd},
+				Command: []string{"/usr/local/bin/etcdctl", cmd},
 			},
 		},
 		InitialDelaySeconds: 10,

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -70,13 +70,13 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 
 func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	// etcd pod is healthy only if it can participate in consensus
-	cmd := "ETCDCTL_API=3 etcdctl endpoint status"
+	cmd := "etcdctl endpoint status"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)
 		if isTLSSecret {
 			tlsFlags = fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, "tls.crt", "tls.key", "ca.crt")
 		}
-		cmd = fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
+		cmd = fmt.Sprintf("etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
 	}
 	return &v1.Probe{
 		Handler: v1.Handler{

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -81,7 +81,7 @@ func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	return &v1.Probe{
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
-				Command: []string{"/usr/local/bin/etcdctl", cmd},
+				Command: []string{fmt.Sprintf("/usr/local/bin/etcdctl %s", cmd)},
 			},
 		},
 		InitialDelaySeconds: 10,

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -71,15 +71,22 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	// etcd pod is healthy only if it can participate in consensus
 	var cmd []string
+	var certFile string
+	var keyFile string
+	var cacertFile string
 	cmd = append(cmd, "etcdctl")
 	if isSecure {
 		cmd = append(cmd, fmt.Sprintf("--endpoints=https://localhost:%d", EtcdClientPort))
 		if isTLSSecret {
-			cmd = append(cmd, fmt.Sprintf("--cert=%s/%s", operatorEtcdTLSDir, "tls.crt"), fmt.Sprintf("--key=%s/%s", operatorEtcdTLSDir, "tls.key"), fmt.Sprintf("--cacert=%s/%s", operatorEtcdTLSDir, "ca.crt"))
+			certFile = "tls.crt"
+    		keyFile = "tls.key"
+			cacertFile = "ca.crt"
 		} else {
-			cmd = append(cmd, fmt.Sprintf("--cert=%s/%s", operatorEtcdTLSDir, etcdutil.CliCertFile), fmt.Sprintf("--key=%s/%s", operatorEtcdTLSDir, etcdutil.CliKeyFile), fmt.Sprintf("--cacert=%s/%s", operatorEtcdTLSDir, etcdutil.CliCAFile))
+			certFile = etcdutil.CliCertFile
+			keyFile = etcdutil.CliKeyFile
+			cacertFile = etcdutil.CliCAFile
 		}
-
+		cmd = append(cmd, fmt.Sprintf("--cert=%s/%s", operatorEtcdTLSDir, certFile), fmt.Sprintf("--key=%s/%s", operatorEtcdTLSDir, keyFile), fmt.Sprintf("--cacert=%s/%s", operatorEtcdTLSDir, cacertFile))
 	}
 	cmd = append(cmd, "endpoint", "status")
 	return &v1.Probe{

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -70,18 +70,18 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 
 func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	// etcd pod is healthy only if it can participate in consensus
-	cmd := "ETCDCTL_API=3 etcdctl endpoint status"
+	cmd := "etcdctl endpoint status"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)
 		if isTLSSecret {
 			tlsFlags = fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, "tls.crt", "tls.key", "ca.crt")
 		}
-		cmd = fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
+		cmd = fmt.Sprintf("etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
 	}
 	return &v1.Probe{
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
-				Command: []string{"/bin/sh", "-ec", cmd},
+				Command: []string{cmd},
 			},
 		},
 		InitialDelaySeconds: 10,

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -70,18 +70,18 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 
 func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	// etcd pod is healthy only if it can participate in consensus
-	cmd := "etcdctl endpoint status"
+	cmd := "ETCDCTL_API=3 etcdctl endpoint status"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)
 		if isTLSSecret {
 			tlsFlags = fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, "tls.crt", "tls.key", "ca.crt")
 		}
-		cmd = fmt.Sprintf("etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
+		cmd = fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
 	}
 	return &v1.Probe{
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
-				Command: []string{cmd},
+				Command: []string{"/bin/sh", "-ec", cmd},
 			},
 		},
 		InitialDelaySeconds: 10,

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -81,7 +81,7 @@ func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	return &v1.Probe{
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
-				Command: []string{cmd},
+				Command: []string{"/usr/local/bin/", cmd},
 			},
 		},
 		InitialDelaySeconds: 10,

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -81,7 +81,7 @@ func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	return &v1.Probe{
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
-				Command: []string{"/bin/sh", "-ec", cmd},
+				Command: []string{cmd},
 			},
 		},
 		InitialDelaySeconds: 10,

--- a/pkg/util/k8sutil/pod_utils_test.go
+++ b/pkg/util/k8sutil/pod_utils_test.go
@@ -1,0 +1,56 @@
+package k8sutil
+
+import (
+	"testing"
+)
+
+func TestNewEtcdProbe(t *testing.T) {
+	isSecure := false
+	isTLSSecret := false
+	expectedCommand := []string{"etcdctl", "endpoint", "status"}
+
+	probe := newEtcdProbe(isSecure, isTLSSecret)
+
+	if len(probe.Handler.Exec.Command) != len(expectedCommand){
+		t.Errorf("expected command=%s, got=%s", expectedCommand, probe.Handler.Exec.Command)
+	}
+	for i, v := range expectedCommand {
+		if v != probe.Handler.Exec.Command[i] {
+			t.Errorf("expected piece=%s, got=%s", v, probe.Handler.Exec.Command[i])
+		}
+	}
+}
+
+func TestNewEtcdProbeWithTLS(t *testing.T) {
+	isSecure := true
+	isTLSSecret := false
+	expectedCommand := []string{"etcdctl", "--endpoints=https://localhost:2379", "--cert=/etc/etcdtls/operator/etcd-tls/etcd-client.crt", "--key=/etc/etcdtls/operator/etcd-tls/etcd-client.key", "--cacert=/etc/etcdtls/operator/etcd-tls/etcd-client-ca.crt", "endpoint", "status"}
+
+	probe := newEtcdProbe(isSecure, isTLSSecret)
+
+	if len(probe.Handler.Exec.Command) != len(expectedCommand){
+		t.Errorf("expected command=%v, got=%v", len(expectedCommand), len(probe.Handler.Exec.Command))
+	}
+	for i, v := range expectedCommand {
+		if v != probe.Handler.Exec.Command[i] {
+			t.Errorf("expected piece=%s, got=%s", v, probe.Handler.Exec.Command[i])
+		}
+	}
+}
+
+func TestNewEtcdProbeWithTLSWithTLSSecret(t *testing.T) {
+	isSecure := true
+	isTLSSecret := true
+	expectedCommand := []string{"etcdctl", "--endpoints=https://localhost:2379", "--cert=/etc/etcdtls/operator/etcd-tls/tls.crt", "--key=/etc/etcdtls/operator/etcd-tls/tls.key", "--cacert=/etc/etcdtls/operator/etcd-tls/ca.crt", "endpoint", "status"}
+
+	probe := newEtcdProbe(isSecure, isTLSSecret)
+
+	if len(probe.Handler.Exec.Command) != len(expectedCommand){
+		t.Errorf("expected command=%v, got=%v", len(expectedCommand), len(probe.Handler.Exec.Command))
+	}
+	for i, v := range expectedCommand {
+		if v != probe.Handler.Exec.Command[i] {
+			t.Errorf("expected piece=%s, got=%s", v, probe.Handler.Exec.Command[i])
+		}
+	}
+}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -65,7 +65,7 @@ func TestCreateClusterDiscovery(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	cluster := e2eutil.NewCluster("test-etcd-", 3)
+	cluster := e2eutil.NewCluster("test-etcd-", 1)
 	cluster = e2eutil.ClusterWithVersion(cluster, "v3.5.7")
 	cluster = e2eutil.ClusterWithRepo(cluster, "quay.io/coreos/etcd")
 	token := getDiscoveryToken(t)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"testing"
 	"time"
-	// "net/http"
-	// "io/ioutil"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	"github.com/coreos/etcd-operator/test/e2e/e2eutil"

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -48,45 +48,46 @@ func TestCreateCluster(t *testing.T) {
 	}
 }
 
-func getDiscoveryToken(t *testing.T) string {
-	resp, err := http.Get("https://discovery.etcd.io/new?size=1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(body)
-}
+// Test not used cause the testing cluster doesn't have aws lb controller, which this version uses
+// func getDiscoveryToken(t *testing.T) string {
+// 	resp, err := http.Get("https://discovery.etcd.io/new?size=1")
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	body, err := ioutil.ReadAll(resp.Body)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	return string(body)
+// }
 
-func TestCreateClusterDiscovery(t *testing.T) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
-	f := framework.Global
-	cluster := e2eutil.NewCluster("test-etcd-", 1)
-	cluster = e2eutil.ClusterWithVersion(cluster, "v3.5.7")
-	cluster = e2eutil.ClusterWithRepo(cluster, "quay.io/coreos/etcd")
-	token := getDiscoveryToken(t)
-	cluster.Spec.ClusteringMode = "discovery"
-	cluster.Spec.ClusterToken = token
+// func TestCreateClusterDiscovery(t *testing.T) {
+// 	if os.Getenv(envParallelTest) == envParallelTestTrue {
+// 		t.Parallel()
+// 	}
+// 	f := framework.Global
+// 	cluster := e2eutil.NewCluster("test-etcd-", 1)
+// 	cluster = e2eutil.ClusterWithVersion(cluster, "v3.5.7")
+// 	cluster = e2eutil.ClusterWithRepo(cluster, "quay.io/coreos/etcd")
+// 	token := getDiscoveryToken(t)
+// 	cluster.Spec.ClusteringMode = "discovery"
+// 	cluster.Spec.ClusterToken = token
 
-	testEtcd, err := e2eutil.CreateCluster(t, context.Background(), f.CRClient, f.Namespace, cluster)
-	if err != nil {
-		t.Fatal(err)
-	}
+// 	testEtcd, err := e2eutil.CreateCluster(t, context.Background(), f.CRClient, f.Namespace, cluster)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	defer func() {
-		if err := e2eutil.DeleteCluster(t, context.Background(), f.CRClient, f.KubeClient, testEtcd); err != nil {
-			t.Fatal(err)
-		}
-	}()
+// 	defer func() {
+// 		if err := e2eutil.DeleteCluster(t, context.Background(), f.CRClient, f.KubeClient, testEtcd); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 	}()
 
-	if _, err := e2eutil.WaitUntilSizeReached(t, context.Background(), f.CRClient, 1, f.RetryAttempts, testEtcd); err != nil {
-		t.Fatalf("failed to create 1 member etcd cluster: %v", err)
-	}
-}
+// 	if _, err := e2eutil.WaitUntilSizeReached(t, context.Background(), f.CRClient, 1, f.RetryAttempts, testEtcd); err != nil {
+// 		t.Fatalf("failed to create 1 member etcd cluster: %v", err)
+// 	}
+// }
 
 // TestPauseControl tests the user can pause the operator from controlling
 // an etcd cluster.

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -108,7 +108,7 @@ func TestEtcdUpgrade(t *testing.T) {
 	}
 	f := framework.Global
 	origEtcd := e2eutil.NewCluster("test-etcd-", 3)
-	origEtcd = e2eutil.ClusterWithVersion(origEtcd, "v3.1.10")
+	origEtcd = e2eutil.ClusterWithVersion(origEtcd, "v3.4.19")
 	origEtcd.Spec.Repository = "quay.io/coreos/etcd"
 	testEtcd, err := e2eutil.CreateCluster(t, context.Background(), f.CRClient, f.Namespace, origEtcd)
 	if err != nil {
@@ -121,12 +121,12 @@ func TestEtcdUpgrade(t *testing.T) {
 		}
 	}()
 
-	err = e2eutil.WaitSizeAndVersionReached(t, context.Background(), f.KubeClient, "v3.1.10", 3, f.RetryAttempts, testEtcd)
+	err = e2eutil.WaitSizeAndVersionReached(t, context.Background(), f.KubeClient, "v3.4.19", 3, f.RetryAttempts, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	targetVersion := "v3.2.13"
+	targetVersion := "v3.4.20"
 	updateFunc := func(cl *api.EtcdCluster) {
 		cl = e2eutil.ClusterWithVersion(cl, targetVersion)
 	}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"testing"
 	"time"
-	"net/http"
-	"io/ioutil"
+	// "net/http"
+	// "io/ioutil"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	"github.com/coreos/etcd-operator/test/e2e/e2eutil"

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -111,3 +111,8 @@ func ClusterWithVersion(cl *api.EtcdCluster, version string) *api.EtcdCluster {
 func NameLabelSelector(name string) map[string]string {
 	return map[string]string{"name": name}
 }
+
+func ClusterWithRepo(cl *api.EtcdCluster, repo string) *api.EtcdCluster {
+	cl.Spec.Repository = repo
+	return cl
+}


### PR DESCRIPTION
Since [version 3.5.7](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md#v357-2023-01-20) changed the docker image [removing dependencies from busybox](https://github.com/etcd-io/etcd/pull/15037) and removed the /bin/sh command ([here](https://github.com/etcd-io/etcd/pull/15037/files#diff-74294ba65db39edad7841a5cf1e353ac2fd1780a324d0eedd1fc244088515d39L4)). With that change the pod never reaches READY state on kubernetes, with the probe failing `OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown`.

This fixes this problem by stop using `/bin/sh` and calling `etcdctl` directly.