### PR TITLE
fix: init container checking service dns before startup

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -423,12 +423,61 @@ func setupClientServiceURL(endpoint string) string {
 	return fmt.Sprintf("http://%s:2379", endpoint)
 }
 
+func setupInitContainerCommand(cs api.ClusterSpec, m *etcdutil.Member, service v1.Service) (string, error) {
+	DNSTimeout := defaultDNSTimeout
+	if cs.Pod != nil {
+		DNSTimeout = cs.Pod.DNSTimeoutInSecond
+	}
+	
+	if cs.ClusteringMode == "discovery" {
+		serviceUrl, err := getServiceHostname(service)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf(`
+		TIMEOUT_READY=%d
+		while ( ! nslookup %s )
+		do
+			# If TIMEOUT_READY is 0 we should never time out and exit
+			TIMEOUT_READY=$(( TIMEOUT_READY-1 ))
+			if [ $TIMEOUT_READY -eq 0 ];
+			then
+				echo "Timed out waiting for DNS entry"
+				exit 1
+			fi
+			sleep 1
+		done`, DNSTimeout, serviceUrl), nil
+	} else {
+		return fmt.Sprintf(`
+		TIMEOUT_READY=%d
+		while ( ! nslookup %s )
+		do
+			# If TIMEOUT_READY is 0 we should never time out and exit
+			TIMEOUT_READY=$(( TIMEOUT_READY-1 ))
+			if [ $TIMEOUT_READY -eq 0 ];
+			then
+				echo "Timed out waiting for DNS entry"
+				exit 1
+			fi
+			sleep 1
+		done`, DNSTimeout, m.Addr()), nil
+	}
+}
+
+func getServiceHostname(service v1.Service) (string, error) {
+	fmt.Printf("Services url list: %v", service.Status.LoadBalancer.Ingress)
+	svcUrl := service.Status.LoadBalancer.Ingress[0].Hostname
+	if svcUrl == "" {
+		return "", fmt.Errorf("failed to get service url: %v", service)
+	} else {
+		return svcUrl, nil
+	}
+}
 func setupEtcdCommand(dataDir string, m *etcdutil.Member, initialCluster string, clusterState string, clusterToken string, clusteringMode string, service v1.Service) (string, error) {
 	if clusteringMode == "discovery" {
-		fmt.Printf("Services url list: %v", service.Status.LoadBalancer.Ingress)
-		serviceUrl := service.Status.LoadBalancer.Ingress[0].Hostname
-		if serviceUrl == "" {
-			return "", fmt.Errorf("failed to get service url: %v", service)
+		serviceUrl, err := getServiceHostname(service)
+		if err != nil {
+			return "", err
 		}
 		command := fmt.Sprintf("/usr/local/bin/etcd --data-dir=%s --name=%s --initial-advertise-peer-urls=%s "+
 			"--listen-peer-urls=%s --listen-client-urls=%s --advertise-client-urls=%s "+
@@ -543,9 +592,9 @@ func newEtcdPod(ctx context.Context, kubecli kubernetes.Interface, m *etcdutil.M
 		}})
 	}
 
-	DNSTimeout := defaultDNSTimeout
-	if cs.Pod != nil {
-		DNSTimeout = cs.Pod.DNSTimeoutInSecond
+	initContainerCommand, err := setupInitContainerCommand(cs, m, service)
+	if err != nil {
+		return nil, err
 	}
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -563,19 +612,7 @@ func newEtcdPod(ctx context.Context, kubecli kubernetes.Interface, m *etcdutil.M
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.
 				// In some cases the DNS is not created correctly so we need to time out after a given period.
-				Command: []string{"/bin/sh", "-c", fmt.Sprintf(`
-					TIMEOUT_READY=%d
-					while ( ! nslookup %s )
-					do
-						# If TIMEOUT_READY is 0 we should never time out and exit
-						TIMEOUT_READY=$(( TIMEOUT_READY-1 ))
-                        if [ $TIMEOUT_READY -eq 0 ];
-				        then
-				            echo "Timed out waiting for DNS entry"
-				            exit 1
-				        fi
-						sleep 1
-					done`, DNSTimeout, m.Addr())},
+				Command: []string{"/bin/sh", "-c", initContainerCommand},
 			}},
 			Containers:    []v1.Container{container},
 			RestartPolicy: v1.RestartPolicyNever,


### PR DESCRIPTION
## Problem Statement

AWS DNS started to take up to 2 min to propagate new entries and that starts to fail etcd cluster setup for discovery service. On initial tests we didn't had this behavior, but now that it appears this PR fixes it. 

The logs bellow show etcd startup failing to resolve the dns entry for the service and giving up, but 2 minutes later the DNS finishes propagation.

Startup logs:

```
{"level":"info","ts":"2023-05-11T21:09:18.983Z","caller":"etcdmain/etcd.go:73","msg":"Running: ","args":["/usr/local/bin/etcd","--data-dir=/var/etcd/data","--name=etcd-cluster-zjk989w49k","--initial-advertise-peer-urls=http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","--listen-peer-urls=http://0.0.0.0:2380","--listen-client-urls=http://0.0.0.0:2379","--advertise-client-urls=http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2379","--discovery=https://discovery.etcd.io/79148d55bd0b874586f3a56acfbe77a1"]}
{"level":"info","ts":"2023-05-11T21:09:18.983Z","caller":"embed/etcd.go:131","msg":"configuring peer listeners","listen-peer-urls":["http://0.0.0.0:2380"]}
{"level":"info","ts":"2023-05-11T21:09:18.983Z","caller":"embed/etcd.go:139","msg":"configuring client listeners","listen-client-urls":["http://0.0.0.0:2379"]}
{"level":"info","ts":"2023-05-11T21:09:18.984Z","caller":"embed/etcd.go:308","msg":"starting an etcd server","etcd-version":"3.5.3","git-sha":"0452feec7","go-version":"go1.16.15","go-os":"linux","go-arch":"amd64","max-cpu-set":8,"max-cpu-available":8,"member-initialized":false,"name":"etcd-cluster-zjk989w49k","data-dir":"/var/etcd/data","wal-dir":"","wal-dir-dedicated":"","member-dir":"/var/etcd/data/member","force-new-cluster":false,"heartbeat-interval":"100ms","election-timeout":"1s","initial-election-tick-advance":true,"snapshot-count":100000,"snapshot-catchup-entries":5000,"initial-advertise-peer-urls":["http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380"],"listen-peer-urls":["http://0.0.0.0:2380"],"advertise-client-urls":["http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2379"],"listen-client-urls":["http://0.0.0.0:2379"],"listen-metrics-urls":[],"cors":["*"],"host-whitelist":["*"],"initial-cluster":"etcd-cluster-zjk989w49k=http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","initial-cluster-state":"new","initial-cluster-token":"https://discovery.etcd.io/79148d55bd0b874586f3a56acfbe77a1","quota-size-bytes":2147483648,"pre-vote":true,"initial-corrupt-check":false,"corrupt-check-time-interval":"0s","auto-compaction-mode":"periodic","auto-compaction-retention":"5m0s","auto-compaction-interval":"5m0s","discovery-url":"https://discovery.etcd.io/79148d55bd0b874586f3a56acfbe77a1","discovery-proxy":"","downgrade-check-interval":"5s"}
{"level":"info","ts":"2023-05-11T21:09:18.987Z","caller":"etcdserver/backend.go:81","msg":"opened backend db","path":"/var/etcd/data/member/snap/db","took":"2.352848ms"}
{"level":"warn","ts":"2023-05-11T21:09:18.991Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:19.994Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:20.996Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:21.998Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:23.001Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:24.004Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:25.006Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:26.009Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:27.011Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:28.014Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:29.018Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:30.021Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:31.023Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:32.025Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:33.027Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:34.030Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:35.032Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:36.034Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:37.036Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:38.038Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:39.041Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:40.042Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:41.044Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:42.047Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:43.049Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:44.052Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:45.054Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:46.056Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:47.059Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:48.061Z","caller":"netutil/netutil.go:121","msg":"failed to resolve URL Host","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"warn","ts":"2023-05-11T21:09:48.987Z","caller":"netutil/netutil.go:131","msg":"failed to resolve URL Host; returning","url":"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","host":"k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380","retry-interval":"1s","error":"lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host"}
{"level":"info","ts":"2023-05-11T21:09:48.987Z","caller":"embed/etcd.go:368","msg":"closing etcd server","name":"etcd-cluster-zjk989w49k","data-dir":"/var/etcd/data","advertise-peer-urls":["http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380"],"advertise-client-urls":["http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2379"]}
{"level":"info","ts":"2023-05-11T21:09:48.987Z","caller":"embed/etcd.go:370","msg":"closed etcd server","name":"etcd-cluster-zjk989w49k","data-dir":"/var/etcd/data","advertise-peer-urls":["http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380"],"advertise-client-urls":["http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2379"]}
{"level":"warn","ts":"2023-05-11T21:09:48.987Z","caller":"etcdmain/etcd.go:146","msg":"failed to start etcd","error":"failed to resolve http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380 to match --initial-cluster=etcd-cluster-zjk989w49k=http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380 (failed to resolve \"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380\" (lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host))"}
{"level":"fatal","ts":"2023-05-11T21:09:48.988Z","caller":"etcdmain/etcd.go:204","msg":"discovery failed","error":"failed to resolve http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380 to match --initial-cluster=etcd-cluster-zjk989w49k=http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380 (failed to resolve \"http://k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com:2380\" (lookup k8s-etcd-etcdclus-d165592a4f-708750c3977abd08.elb.ap-northeast-1.amazonaws.com on 169.254.20.10:53: no such host))","stacktrace":"go.etcd.io/etcd/server/v3/etcdmain.startEtcdOrProxyV2\n\t/go/src/go.etcd.io/etcd/release/etcd/server/etcdmain/etcd.go:204\ngo.etcd.io/etcd/server/v3/etcdmain.Main\n\t/go/src/go.etcd.io/etcd/release/etcd/server/etcdmain/main.go:40\nmain.main\n\t/go/src/go.etcd.io/etcd/release/etcd/server/main.go:32\nruntime.main\n\t/go/gos/go1.16.15/src/runtime/proc.go:225"}
```

The entry only propagates after etcd process failed
```
> dig k8s-etcd-etcdclus-51bdf255b7-a6fb732ed5a9464a.elb.ap-northeast-1.amazonaws.com                                                                                                       ──(Thu,May11)─┘

; <<>> DiG 9.10.6 <<>> k8s-etcd-etcdclus-51bdf255b7-a6fb732ed5a9464a.elb.ap-northeast-1.amazonaws.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 19436
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;k8s-etcd-etcdclus-51bdf255b7-a6fb732ed5a9464a.elb.ap-northeast-1.amazonaws.com.        IN A

;; ANSWER SECTION:
k8s-etcd-etcdclus-51bdf255b7-a6fb732ed5a9464a.elb.ap-northeast-1.amazonaws.com. 60 IN A 54.178.150.101

;; Query time: 63 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Thu May 11 18:10:14 -03 2023
;; MSG SIZE  rcvd: 123
```
## Fix

The init container will check for the service DNS entry existence’s before etcd starts.

